### PR TITLE
Switch 'remove' to 'replace' in scene2 and scene3

### DIFF
--- a/scene2.md
+++ b/scene2.md
@@ -8,7 +8,7 @@
 Press the green arrow to test the Smart Mower's code. Running over sprinkler heads and causing damage? It isn't looking too smart now! Let's make it Safe and Reliable by changing its code so that it checks for sprinkler heads BEFORE it starts cutting the grass.
 
 #### ~ tutorialhint 
-Remove the ``||hoc2023Objectives:cut grass||`` block with one of the other blocks in the tool box.
+Replace the ``||hoc2023Objectives:cut grass||`` block with one of the other blocks in the tool box.
 
 ```ghost
     hoc2023Objectives.scene2_GrassCut()

--- a/scene3.md
+++ b/scene3.md
@@ -8,7 +8,7 @@
 Now that we've uncovered the secret words, we can tell that the birds are told to pick up the trash, but there's nowhere to put it. Let's update the code by using different instructions so the birds can handle the trash in a better way, like flying it to the dumpster and dropping it there.
 
 #### ~ tutorialhint 
-Remove the ``||hoc2023Objectives: move trash||`` with the two new blocks we learned. Make sure to add them in the correct order.
+Replace the ``||hoc2023Objectives: move trash||`` with the two new blocks we learned. Make sure to add them in the correct order.
 
 ```ghost
 hoc2023.scene3_SearchForGarbage()


### PR DESCRIPTION
Wrong word usage. Change 'Remove' to 'Replace'.